### PR TITLE
Fix initial image render & add modal for images

### DIFF
--- a/src/components/ImageModal.jsx
+++ b/src/components/ImageModal.jsx
@@ -1,11 +1,11 @@
-import ProductImages from "./ProductImages";
+import ProductImages from './ProductImages'
 
-const ImageModal = ({ images }) => {
-  return (
-    <div>
-      <ProductImages images={images} />
-    </div>
-  );
-};
+const ImageModal = ({ imageModal }) => {
+	return (
+		<div>
+			<ProductImages images={imageModal} />
+		</div>
+	)
+}
 
-export default ImageModal;
+export default ImageModal

--- a/src/components/ImageModal.jsx
+++ b/src/components/ImageModal.jsx
@@ -1,0 +1,11 @@
+import ProductImages from "./ProductImages";
+
+const ImageModal = ({ images }) => {
+  return (
+    <div>
+      <ProductImages images={images} />
+    </div>
+  );
+};
+
+export default ImageModal;

--- a/src/components/ProductImages.jsx
+++ b/src/components/ProductImages.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 
 const ProductImages = ({images}) => {
-  const [image, setImage] = useState(images.product1);
+  const [image, setImage] = useState(images[0].productPic);
 
   return (
 			<>

--- a/src/components/ProductImages.jsx
+++ b/src/components/ProductImages.jsx
@@ -1,21 +1,24 @@
-import { useState } from 'react'
+import { useState } from "react";
 
-
-const ProductImages = ({images}) => {
+const ProductImages = ({ images, setIsOpened }) => {
   const [image, setImage] = useState(images[0].productPic);
 
   return (
-			<>
-				<div>
-					<img src={image} alt='' />
-				</div>
-				<div className='thumbnails'>
-					{images.map((product) => (
-						<img src={product.thumbnail} onClick={() => setImage(product.productPic)} alt='' />
-					))}
-				</div>
-			</>
-		)
-}
+    <>
+      <div>
+        <img src={image} alt="" onClick={() => setIsOpened(true)} />
+      </div>
+      <div className="thumbnails">
+        {images.map((product) => (
+          <img
+            src={product.thumbnail}
+            onClick={() => setImage(product.productPic)}
+            alt=""
+          />
+        ))}
+      </div>
+    </>
+  );
+};
 
-export default ProductImages
+export default ProductImages;

--- a/src/components/ProductPage.jsx
+++ b/src/components/ProductPage.jsx
@@ -1,21 +1,21 @@
 //data
-import { useState } from "react";
-import data from "../data";
-import ImageModal from "./ImageModal";
+import { useState } from 'react'
+import data from '../data'
+import ImageModal from './ImageModal'
 //components
-import ProductDetails from "./ProductDetails";
-import ProductImages from "./ProductImages";
+import ProductDetails from './ProductDetails'
+import ProductImages from './ProductImages'
 
 const ProductPage = () => {
-  const [isOpened, setIsOpened] = useState(false);
+	const [isOpened, setIsOpened] = useState(false)
 
-  return (
-    <main>
-      {isOpened && <ImageModal images={data.productImages} />}
-      <ProductImages images={data.productImages} setIsOpened={setIsOpened} />
-      <ProductDetails item={data} />
-    </main>
-  );
-};
+	return (
+		<main>
+			{isOpened && <ImageModal imageModal={data.productImages} />}
+			<ProductImages images={data.productImages} setIsOpened={setIsOpened} />
+			<ProductDetails item={data} />
+		</main>
+	)
+}
 
-export default ProductPage;
+export default ProductPage

--- a/src/components/ProductPage.jsx
+++ b/src/components/ProductPage.jsx
@@ -1,16 +1,21 @@
 //data
-import data from '../data'
+import { useState } from "react";
+import data from "../data";
+import ImageModal from "./ImageModal";
 //components
-import ProductDetails from './ProductDetails'
-import ProductImages from './ProductImages'
+import ProductDetails from "./ProductDetails";
+import ProductImages from "./ProductImages";
 
 const ProductPage = () => {
+  const [isOpened, setIsOpened] = useState(false);
+
   return (
     <main>
-      <ProductImages images={data.productImages}/>
-      <ProductDetails item={data}/>
+      {isOpened && <ImageModal images={data.productImages} />}
+      <ProductImages images={data.productImages} setIsOpened={setIsOpened} />
+      <ProductDetails item={data} />
     </main>
-  )
-}
+  );
+};
 
-export default ProductPage
+export default ProductPage;


### PR DESCRIPTION
## Link Issues

Closes #8 
Closes #9 

## Description

- Fix initial image render. Now initial image renders when the page is opened.
- When the user clicks on the big image, a modal of images will show.
  Because we are not styling this component yet, the modal will be shown as a duplicate of images on the top of `ProductImages` component.

## Type of Changes

🛠 Fix bugs
⭐ New feature

## Screenshot

### Render initial image
![initial-img](https://user-images.githubusercontent.com/45172775/154813514-68efca1d-0c2f-4695-bc69-cfad8c3b606e.jpg)

### Images Modal

![img-modal](https://user-images.githubusercontent.com/45172775/154813552-204d4e68-7263-4123-b168-1035b066a2aa.jpg)

## Testing Steps

1. Pull `fix-initial-image` branch to your local and navigate to the branch.
2. Run `npm start`.
3. When the page renders, you should see the initial big image.
4. Click on the big image.
  You should see a duplicate of the image and the thumbnails.
