### PR TITLE
Add quantity counter in PurchasePlan component

### DIFF
--- a/src/components/ProductDetails.jsx
+++ b/src/components/ProductDetails.jsx
@@ -1,19 +1,23 @@
-const ProductDetails = ({item}) => {
+import PurchasePlan from './PurchasePlan'
+
+const ProductDetails = ({ item }) => {
 	const applyDiscount = () => {
-		return (item.price - (item.price * (item.discount / 100))).toFixed(2)
+		return (item.price - item.price * (item.discount / 100)).toFixed(2)
 	}
 
-  return (
-			<>
-				<h1>Sneaker Company</h1>
-				<h2>{item.collection}</h2>
-				<p>{item.description}</p>
+	return (
+		<>
+			<h1>Sneaker Company</h1>
+			<h2>{item.collection}</h2>
+			<p>{item.description}</p>
 
-				<p>${applyDiscount()}</p>
-				<p>{item.discount}%</p>
-				<p>${item.price}</p>
-			</>
-		)
+			<p>${applyDiscount()}</p>
+			<p>{item.discount}%</p>
+			<p>${item.price}</p>
+
+			<PurchasePlan />
+		</>
+	)
 }
 
 export default ProductDetails

--- a/src/components/ProductPage.jsx
+++ b/src/components/ProductPage.jsx
@@ -3,14 +3,16 @@ import data from '../data'
 //components
 import ProductDetails from './ProductDetails'
 import ProductImages from './ProductImages'
+import PurchasePlan from './PurchasePlan'
 
 const ProductPage = () => {
-  return (
-    <main>
-      <ProductImages images={data.productImages}/>
-      <ProductDetails item={data}/>
-    </main>
-  )
+	return (
+		<main>
+			<ProductImages images={data.productImages} />
+			<ProductDetails item={data} />
+			<PurchasePlan />
+		</main>
+	)
 }
 
 export default ProductPage

--- a/src/components/ProductPage.jsx
+++ b/src/components/ProductPage.jsx
@@ -5,7 +5,6 @@ import ImageModal from './ImageModal'
 //components
 import ProductDetails from './ProductDetails'
 import ProductImages from './ProductImages'
-import PurchasePlan from './PurchasePlan'
 
 const ProductPage = () => {
 	const [isOpened, setIsOpened] = useState(false)
@@ -15,7 +14,6 @@ const ProductPage = () => {
 			{isOpened && <ImageModal imageModal={data.productImages} />}
 			<ProductImages images={data.productImages} setIsOpened={setIsOpened} />
 			<ProductDetails item={data} />
-			<PurchasePlan />
 		</main>
 	)
 }

--- a/src/components/PurchasePlan.jsx
+++ b/src/components/PurchasePlan.jsx
@@ -1,0 +1,33 @@
+import shoppingCart from '../assets/images/icon-cart.svg'
+import { useState } from 'react'
+
+const PurchasePlan = () => {
+	const [quantity, setQuantity] = useState(0)
+
+	const increaseQuantity = () => {
+		setQuantity((prevQuantity) => prevQuantity + 1)
+	}
+
+	const decreaseQuantity = () => {
+		if (quantity > 0) {
+			setQuantity((prevQuantity) => prevQuantity - 1)
+		} else {
+			setQuantity(0)
+		}
+	}
+
+	return (
+		<>
+			<button onClick={decreaseQuantity}>-</button>
+			<span>{quantity}</span>
+			<button onClick={increaseQuantity}>+</button>
+
+			<button type='submit'>
+				<img src={shoppingCart} alt='Shopping cart icon' />
+				Add to chart
+			</button>
+		</>
+	)
+}
+
+export default PurchasePlan


### PR DESCRIPTION
Co-authored-by: Reda Baha <baha.redaaaa@gmail.com>

## Link Issue

Closes #11 

## Description

- Created a new component of `PurchasePlan` that holds quantity counter and an `Add to chart` button.

## Type of change

⭐ New feature

## Screenshot
![qty-counter](https://user-images.githubusercontent.com/45172775/154846683-dea6a545-56ff-43d3-b38c-46dee2a03873.jpg)

## Testing steps

1. Run `npm start`.
2. The quantity counter and button are rendered at the bottom of the page.
3. Click on the + button to increase the quantity.
4. Click on the - button to decrease the quantity.
5. Counter will not go below 0.
 