### PR TITLE
Add SVG for plus and minus buttons, add alt texts and key

### DIFF
--- a/src/components/ImageModal.jsx
+++ b/src/components/ImageModal.jsx
@@ -1,12 +1,13 @@
-import ProductImages from "./ProductImages";
-import close from "../assets/images/icon-close.svg";
-const ImageModal = ({ imageModal, setIsOpened }) => {
-  return (
-    <div>
-      <img src={close} alt="" onClick={() => setIsOpened(false)} />
-      <ProductImages images={imageModal} arrows />
-    </div>
-  );
-};
+import ProductImages from './ProductImages'
+import close from '../assets/images/icon-close.svg'
 
-export default ImageModal;
+const ImageModal = ({ imageModal, setIsOpened }) => {
+	return (
+		<div>
+			<img src={close} alt='close' onClick={() => setIsOpened(false)} />
+			<ProductImages images={imageModal} arrows />
+		</div>
+	)
+}
+
+export default ImageModal

--- a/src/components/ProductImages.jsx
+++ b/src/components/ProductImages.jsx
@@ -41,6 +41,7 @@ const ProductImages = ({ images, setIsOpened, arrows }) => {
       <div className="thumbnails">
         {images.map((product, index) => (
           <img
+            key={product.id}
             src={product.thumbnail}
             onClick={() => {
               setImage(product.productPic);

--- a/src/components/ProductImages.jsx
+++ b/src/components/ProductImages.jsx
@@ -1,61 +1,63 @@
-import { useState } from "react";
-import nextArrow from "../assets/images/icon-next.svg";
-import previousArrow from "../assets/images/icon-previous.svg";
+import { useState } from 'react'
+import nextArrow from '../assets/images/icon-next.svg'
+import previousArrow from '../assets/images/icon-previous.svg'
 
 const ProductImages = ({ images, setIsOpened, arrows }) => {
-  const [index, setIndex] = useState(0);
-  const [image, setImage] = useState(images[0].productPic);
+	const [index, setIndex] = useState(0)
+	const [image, setImage] = useState(images[0].productPic)
+	const [altText, setAltText] = useState(images[0].altText)
 
-  const moveToNextImage = () => {
-    if (index === 3) {
-      return;
-    } else {
-      const newIndex = index + 1;
-      setIndex(newIndex);
-      setImage(images[newIndex].productPic);
-    }
-  };
+	const moveToNextImage = () => {
+		if (index === 3) {
+			return
+		} else {
+			const newIndex = index + 1
+			setIndex(newIndex)
+			setImage(images[newIndex].productPic)
+		}
+	}
 
-  const moveToPreviousImage = () => {
-    if (index === 0) {
-      return;
-    } else {
-      const newIndex = index - 1;
-      setIndex(newIndex);
-      setImage(images[newIndex].productPic);
-    }
-  };
+	const moveToPreviousImage = () => {
+		if (index === 0) {
+			return
+		} else {
+			const newIndex = index - 1
+			setIndex(newIndex)
+			setImage(images[newIndex].productPic)
+		}
+	}
 
-  return (
-    <>
-      {arrows && (
-        <img
-          src={previousArrow}
-          alt="previous arrow"
-          onClick={moveToPreviousImage}
-        />
-      )}
-      <div>
-        <img src={image} alt="" onClick={() => setIsOpened(true)} />
-      </div>
-      <div className="thumbnails">
-        {images.map((product, index) => (
-          <img
-            key={product.id}
-            src={product.thumbnail}
-            onClick={() => {
-              setImage(product.productPic);
-              setIndex(index);
-            }}
-            alt=""
-          />
-        ))}
-      </div>
-      {arrows && (
-        <img src={nextArrow} alt="next arrow" onClick={moveToNextImage} />
-      )}
-    </>
-  );
-};
+	return (
+		<>
+			{arrows && (
+				<img
+					src={previousArrow}
+					alt='previous arrow'
+					onClick={moveToPreviousImage}
+				/>
+			)}
+			<div>
+				<img src={image} alt={altText} onClick={() => setIsOpened(true)} />
+			</div>
+			<div className='thumbnails'>
+				{images.map((product, index) => (
+					<img
+						key={product.id}
+						src={product.thumbnail}
+						onClick={() => {
+							setImage(product.productPic)
+							setAltText(product.altText)
+							setIndex(index)
+						}}
+						alt={product.thumbnailAltText}
+					/>
+				))}
+			</div>
+			{arrows && (
+				<img src={nextArrow} alt='next arrow' onClick={moveToNextImage} />
+			)}
+		</>
+	)
+}
 
-export default ProductImages;
+export default ProductImages

--- a/src/components/PurchasePlan.jsx
+++ b/src/components/PurchasePlan.jsx
@@ -1,4 +1,7 @@
 import shoppingCart from '../assets/images/icon-cart.svg'
+import plus from '../assets/images/icon-plus.svg'
+import minus from '../assets/images/icon-minus.svg'
+
 import { useState } from 'react'
 
 const PurchasePlan = () => {
@@ -18,9 +21,13 @@ const PurchasePlan = () => {
 
 	return (
 		<>
-			<button onClick={decreaseQuantity}>-</button>
+			<button onClick={decreaseQuantity}>
+				<img src={minus} alt='minus' />
+			</button>
 			<span>{quantity}</span>
-			<button onClick={increaseQuantity}>+</button>
+			<button onClick={increaseQuantity}>
+				<img src={plus} alt='plus' />
+			</button>
 
 			<button type='submit'>
 				<img src={shoppingCart} alt='Shopping cart icon' />

--- a/src/data.js
+++ b/src/data.js
@@ -18,18 +18,22 @@ const data = {
 		{
 			productPic: product1,
 			thumbnail: productThumbnail1,
+			id: 1,
 		},
 		{
 			productPic: product2,
 			thumbnail: productThumbnail2,
+			id: 2,
 		},
 		{
 			productPic: product3,
 			thumbnail: productThumbnail3,
+			id: 3,
 		},
 		{
 			productPic: product4,
 			thumbnail: productThumbnail4,
+			id: 4,
 		},
 	],
 }

--- a/src/data.js
+++ b/src/data.js
@@ -18,21 +18,37 @@ const data = {
 		{
 			productPic: product1,
 			thumbnail: productThumbnail1,
+			altText:
+				'A white and light brown color sneaker view from side and the other pair bottom view',
+			thumbnailAltText:
+				'Thumbnail of a white and light brown color sneaker view from side and the other pair bottom view',
 			id: 1,
 		},
 		{
 			productPic: product2,
 			thumbnail: productThumbnail2,
+			altText:
+				'Back view of a white and light brown color sneaker on a stack of white rocks and the other pair in standing position next to it',
+			thumbnailAltText:
+				'Thumbnail of back view of a white and light brown color sneaker on a stack of white rocks and the other pair in standing position next to it',
 			id: 2,
 		},
 		{
 			productPic: product3,
 			thumbnail: productThumbnail3,
+			altText:
+				'Outer side view of a white and light brown color sneaker on a stack of white rocks',
+			thumbnailAltText:
+				'Thumbnail of outer side view of a white and light brown color sneaker on a stack of white rocks',
 			id: 3,
 		},
 		{
 			productPic: product4,
 			thumbnail: productThumbnail4,
+			altText:
+				'Inner side view of a white and light brown color sneaker on a stack of white rocks',
+			thumbnailAltText:
+				'Thumbnail of inner side view of a white and light brown color sneaker on a stack of white rocks',
 			id: 4,
 		},
 	],


### PR DESCRIPTION
## Link Issues

Closes #17 
Closes #18 

## Description

- Add SVG to the plus and minus buttons for the quantity counter.
- Add dynamic alt texts for product images and thumbnails.
- Add key to the thumbnails' map.

## Type of changes

🛠 Fix bugs
⭐ New features

## Screenshot

- Plus and minus SVG for buttons.
![svg-btn](https://user-images.githubusercontent.com/45172775/155414800-83336cfb-3141-4587-848f-080c6736ccfd.JPG)

- Alt text example
![alt-text-example](https://user-images.githubusercontent.com/45172775/155415173-5f6e6038-2976-4dc7-8868-b514c1e910cf.JPG)

- No more key warning on browser's devtools
![no-key-warning](https://user-images.githubusercontent.com/45172775/155415382-071f8e1e-1ef2-4c43-b39b-6e0a60d56c4c.JPG)

## Testing Steps

- Run `npm start`
- See the buttons for the quantity counter at the bottom of the page.
- Open the browser's dev tools.
- Navigate to the console tab. 
- There should be no more warning for an unavailable key prop.
- Navigate to the elements tab.
- Inspect the images.
- There should be alt text available for each image.
- If you inspect the big image (both on the page and the image modal), the alt text will change according to the image whenever you click the thumbnails.
