### PR TITLE
Add reset for quantity

### DIFF
--- a/src/components/PurchasePlan.jsx
+++ b/src/components/PurchasePlan.jsx
@@ -34,6 +34,7 @@ const PurchasePlan = ({
 			thumbnail,
 			thumbnailAltText,
 		}))
+		setQuantity(0)
 	}
 
 	return (


### PR DESCRIPTION
Co-authored-by: Reda Baha <baha.redaaaa@gmail.com>

## Link Issue

Closes #22 

## Description

- Reset the quantity to 0 after the user clicks the "Add to chart button".

## Type of Changes

🛠 Fix bugs

## Testing Steps

1. Run `npm start`.
2. Go to the quantity counter at the bottom of the page.
3. Insert some quantity and click the "Add to chart" button.
4. Now the quantity should reset to 0 after the button click.